### PR TITLE
Makes it possible to display just a subset of the Jenkins jobs, by using 

### DIFF
--- a/getBuilds.php
+++ b/getBuilds.php
@@ -1,10 +1,14 @@
-<?php	
+<?php
 require_once ('lib/MockCI.php');
 require_once ('lib/JenkinsCI.php');
 require_once ('lib/Exceptions.php');
 
 $result = '';
-$ci = new JenkinsCI();
+if (isset($_GET['view'])) {
+	$ci = new JenkinsCI($_GET['view']);
+} else {
+	$ci = new JenkinsCI();
+}
 
 try {
 	$jobs = $ci->getAllJobs();
@@ -16,7 +20,7 @@ try {
 if (!is_array($result)) {
 	$html = '';
 	foreach ($jobs as $job) {
-		$blame = null;	
+		$blame = null;
 		if ($job['status'][0] == 'failed') {
 			$blame = "<br /><span class='blame'>{$job['blame']}</span>" ;
 		}

--- a/index.php
+++ b/index.php
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-		<link rel="stylesheet" href="style.css" type="text/css" media="screen" title="main StyleSheet" charset="utf-8" /> 
-		
+		<link rel="stylesheet" href="style.css" type="text/css" media="screen" title="main StyleSheet" charset="utf-8" />
+
 		<title>buildiator</title>
 	</head>
 	<body>
@@ -11,7 +11,7 @@
 		<script>
 		var lastdata;
 		function updateJobs(){
-			$.getJSON('getBuilds.php', function(data){
+			$.getJSON('getBuilds.php?view=<?= $_GET['view'] ?>', function(data){
 				if (data.content != lastdata){
 					lastdata = data.content;
 					$('#jobs').html(data.content);
@@ -19,17 +19,17 @@
 				setTimeout('updateJobs()', 5000);
 			});
 
-			
+
 		}
-		
+
 		$(document).ajaxError(function() {
 			//if there was an error updating, wait a bit longer and try again
 			setTimeout('updateJobs()', 10000);
 		});
-		
+
 		$(document).ready(function(){
 			updateJobs();
-			
+
 			var count = 0;
 			setInterval(function() {
 				count++;
@@ -46,7 +46,7 @@
 				1000
 			);
 		});
-		
+
 		</script>
 		<ul id="jobs">
 			<!--this is where the jobs go-->


### PR DESCRIPTION
Makes it possible to display just a subset of the Jenkins jobs, by using index.php?view=view_name :
1. Adds the 'view' parameter to the JenkinsCI class. By default, it's null and points to all jobs.
2. getBuilds.php now uses $_GET['view'] to create the right JenkinsCI() instance.
3. In index.php, we forward the $_GET['view'] to getBuilds.php
